### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ----
 
 > [!TIP]
-> # 3rd Party Hosted Instance: https://wpdl.us <br/>
+> # Android Guide (With Termux): [WPDL-Android](https://github.com/sipsuru/wp-downloader-android) <br/>
 
 > [!TIP]
 > # Desktop Version (Electron Wrap): [WPDL-Electron](https://github.com/sipsuru/wp-downloader-electron)


### PR DESCRIPTION
- The hosted instance (wpdl.us) is not up, so removed.
- Added Guide Repo link to Use wp-downloader, in android devices with Termux + NodeJS