### PR TITLE
Update htmlv2.pug - Fixed Top and Bottom Controllers not Activating, Added Per-Story ScrollSave Support.

### DIFF
--- a/templates/htmlv2.pug
+++ b/templates/htmlv2.pug
@@ -39,6 +39,8 @@ style.
 		display: flex;
 		flex-direction: column;
 		line-height: 1.5;
+		word-wrap: break-word;
+		overflow-wrap: break-word;
 	}
 
 	.part img {
@@ -160,6 +162,7 @@ html(lang=langName)
 		meta(charset="UTF-8")
 		title= book.title
 		meta(name="viewport" content="width=device-width, initial-scale=1.0")
+		meta(name="scroll-key" content= book.id)
 
 	body
 
@@ -203,7 +206,13 @@ html(lang=langName)
 
 script.
 	const fontList = ["Arial, sans-serif", "Verdana, sans-serif", "Cambria, serif", "cursive", "monospace"];
-	let scrollsave = localStorage.getItem("scrollsave");
+	const scrollKey = document.querySelector('meta[name="scroll-key"]')?.content;
+	let scrollsave;
+	if (scrollKey) {
+		scrollsave = localStorage.getItem(`scrollsave_${scrollKey}`);
+	} else {
+		console.warn("No scroll key defined in the HTML.");
+	}	
 	let fontsize = localStorage.getItem("fontsize");
 	let colormode = localStorage.getItem("colormode");
 	let font = localStorage.getItem("font");
@@ -249,7 +258,7 @@ script.
 		window.clearTimeout(isScrolling);
 
 		isScrolling = setTimeout(() => {
-			localStorage.setItem("scrollsave", currentScroll.toString());
+			localStorage.setItem(`scrollsave_${scrollKey}`, currentScroll.toString());
 		}, 80);
 
 	});

--- a/templates/htmlv2.pug
+++ b/templates/htmlv2.pug
@@ -228,11 +228,13 @@ script.
 	}
 
 	window.addEventListener("click", (event) => {
-          if (!event.composedPath().some((el) => el.id === "top-control" || el.id === "bottom-control")) {
-              document.querySelector("#top-control").classList.toggle("active");
-              document.querySelector("#bottom-control").classList.toggle("active");
-          }
-        });
+
+		if(!event.composedPath().some((el) => el.id === "top-control" || el.id === "bottom-control")){
+			document.querySelector("#top-control").classList.toggle("active");
+			document.querySelector("#bottom-control").classList.toggle("active");
+		}
+
+	});
 
 	let isScrolling;
 

--- a/templates/htmlv2.pug
+++ b/templates/htmlv2.pug
@@ -228,13 +228,11 @@ script.
 	}
 
 	window.addEventListener("click", (event) => {
-
-		if(!event.path.find((el) => el.id === "top-control" || el.id === "bottom-control")){
-			document.querySelector("#top-control").classList.toggle("active");
-			document.querySelector("#bottom-control").classList.toggle("active");
-		}
-
-	});
+          if (!event.composedPath().some((el) => el.id === "top-control" || el.id === "bottom-control")) {
+              document.querySelector("#top-control").classList.toggle("active");
+              document.querySelector("#bottom-control").classList.toggle("active");
+          }
+        });
 
 	let isScrolling;
 


### PR DESCRIPTION
Updated how top and bottom controllers activate and deactivate in html.
Use event.composedPath() instead of event.path.find(), which didn't work.

---

Newer Update:
Add per-story scrollsave support.

Browsers treat file:// (desktop) and content:// (android) urls as from the same origin regadless the directory they're in. So if we have multiple stories downloaded, the scrollsave value is shared among them.

By adding book id to the localStorage key, we can assure that scrollsave is specific to each story.